### PR TITLE
#78 Refactor Frontend to Handle new API endpoints

### DIFF
--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -1,6 +1,9 @@
 {
-  "extends": "airbnb-base",
+  "extends": "airbnb",
   "env": {
     "jest": true
+  },
+  "rules": {
+    "linebreak-style": "off"
   }
 }

--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "airbnb",
+  "extends": "airbnb-base",
   "env": {
     "jest": true
   },

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -2,5 +2,8 @@
   "extends": "airbnb",
   "env": {
     "jest": true
+  },
+  "rules": {
+    "linebreak-style": "off"
   }
 }

--- a/frontend/src/services/login.js
+++ b/frontend/src/services/login.js
@@ -12,18 +12,18 @@ const prodAxios = axios.create({
 const isDev = true; // manual switch
 const axiosService = isDev ? devAxios : prodAxios;
 
-const addUser = 'rest/api/add-user';
-const logUser = 'rest/api/login';
+const addUser = 'api/users';
+const logUser = 'api/login';
 
 // calls are this easy for json formatted https://github.com/axios/axios#example
 const register = async (payload) => {
   const response = await axiosService.post(addUser, payload);
-  return response.data;
+  return response;
 };
 
 const login = async (payload) => {
   const response = await axiosService.post(logUser, payload);
-  return response.data;
+  return response;
 };
 
 // For export

--- a/frontend/src/views/Dashboard.js
+++ b/frontend/src/views/Dashboard.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-filename-extension */
 import React, { useState } from 'react';
 import {
-  // eslint-disable-next-line no-unused-vars
+  // eslint-disable no-unused-vars
   ImageBackground, View, Text, StyleSheet, TouchableOpacity,
 } from 'react-native';
 import { useLocation } from 'react-router-dom';
@@ -14,7 +14,7 @@ const getInitialNameState = () => {
 };
 
 function Dashboard() {
-  const { initialName, initialRole } = getInitialNameState();
+  const { name, role } = getInitialNameState();
 
   const styles = StyleSheet.create({
     image: {
@@ -93,8 +93,8 @@ function Dashboard() {
     },
   });
 
-  // eslint-disable-next-line no-unused-vars
-  const [message, setMessage] = useState(`Welcome ${initialName}. Your role is ${initialRole}.`);
+
+  const [message, setMessage] = useState(`Welcome ${name}. Your role is ${role}.`);
   const getMessage = () => message;
 
   return (

--- a/frontend/src/views/Dashboard.js
+++ b/frontend/src/views/Dashboard.js
@@ -1,7 +1,7 @@
+/* eslint-disable no-unused-vars */
 /* eslint-disable react/jsx-filename-extension */
 import React, { useState } from 'react';
 import {
-  // eslint-disable no-unused-vars
   ImageBackground, View, Text, StyleSheet, TouchableOpacity,
 } from 'react-native';
 import { useLocation } from 'react-router-dom';
@@ -92,7 +92,6 @@ function Dashboard() {
       fontSize: 16,
     },
   });
-
 
   const [message, setMessage] = useState(`Welcome ${name}. Your role is ${role}.`);
   const getMessage = () => message;

--- a/frontend/src/views/LoginScreen.js
+++ b/frontend/src/views/LoginScreen.js
@@ -1,5 +1,4 @@
 /* eslint-disable react/jsx-filename-extension */
-/* eslint-disable no-unneeded-ternary */
 import React, { useState } from 'react';
 import {
   ImageBackground, View, Text, StyleSheet, TouchableOpacity, TextInput,
@@ -51,14 +50,10 @@ function LoginScreen() {
       const response = isLogin
         ? await loginService.login(payload)
         : await loginService.register(payload);
-      if (response.includes('error') || response.includes('Error')) {
-        setIsError(true);
-        setMessage(response);
-      } else {
+      if (response.status === 200) {
         setIsError(false);
-        const jsonResponse = response[0];
         if (isLogin) {
-          navigate('/dashboard', { state: { name: jsonResponse.firstName, role: jsonResponse.role } });
+          navigate('/dashboard', { state: { name: response.data.firstName, role: response.data.role } });
         } else {
           setMessage('Thank you for registering.');
           setIsLogin(true);
@@ -66,7 +61,7 @@ function LoginScreen() {
       }
     } catch (exception) {
       setIsError(true);
-      setMessage(exception);
+      setMessage('Error: Wrong Credentials');
     }
   };
 


### PR DESCRIPTION
Closes #78 

**Description**
- Changed old API endpoints to `api/users` and `api/login`
- Deconstruct json response to include status codes in the frontend
- Edited props passed to dashboard so they are not undefined

**Approve if the following can be completed**
- [ ] Log in with good credentials. Should redirect to dashboard with correct name & role
- [ ] Log in with wrong credentials. Should stay on login page with error message
- [ ] Run `npm run test` on frontend and backend should pass all tests
- [ ] All API requests should match the endpoints listed above 