### PR TITLE
#127 token payload mistake

### DIFF
--- a/controllers/login.js
+++ b/controllers/login.js
@@ -29,8 +29,6 @@ loginRouter.post('/', async (request, response) => {
   // generating the JWT token
   const tokenJWT = jwt.sign(tokenPayload, process.env.ACCESS_TOKEN_SECRET, { expiresIn: '2h' }, {});
 
-  console.log(tokenPayload);
-
   const responsePayload = {
     auth: true,
     token: tokenJWT,

--- a/controllers/login.js
+++ b/controllers/login.js
@@ -23,8 +23,7 @@ loginRouter.post('/', async (request, response) => {
   }
 
   const tokenPayload = {
-    email: user.email,
-    role: user.role,
+    id: user.id,
   };
 
   // generating the JWT token

--- a/controllers/login.js
+++ b/controllers/login.js
@@ -29,6 +29,8 @@ loginRouter.post('/', async (request, response) => {
   // generating the JWT token
   const tokenJWT = jwt.sign(tokenPayload, process.env.ACCESS_TOKEN_SECRET, { expiresIn: '2h' }, {});
 
+  console.log(tokenPayload);
+
   const responsePayload = {
     auth: true,
     token: tokenJWT,

--- a/tests/helperUsers.js
+++ b/tests/helperUsers.js
@@ -1,3 +1,5 @@
+const User = require('../models/user');
+
 const testPatients = {
   TEST_PATIENT1: {
     email: 'testpatient1@gmail.com',
@@ -42,8 +44,16 @@ const testAdmins = {
   },
 };
 
+const getUserId = async (userJson) => {
+  const user = await User.findOne({ email: userJson.email });
+
+  // eslint-disable-next-line no-underscore-dangle
+  return user.id;
+};
+
 module.exports = {
   testPatients,
   testDoctors,
   testAdmins,
+  getUserId,
 };

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -1,7 +1,7 @@
 const mongoose = require('mongoose');
 const supertest = require('supertest');
-const bcrypt = require('bcrypt');
-const jwt = require('jsonwebtoken');
+// const bcrypt = require('bcrypt');
+// const jwt = require('jsonwebtoken');
 const app = require('../app');
 const User = require('../models/user');
 const usersHelper = require('./helperUsers');
@@ -12,7 +12,7 @@ const api = supertest(app);
 // Get predefined test users from usersHelper
 const { TEST_PATIENT1, TEST_PATIENT2 } = usersHelper.testPatients;
 const { TEST_DOCTOR1 } = usersHelper.testDoctors;
-const nonHashedPassword = TEST_PATIENT1.password;
+// const nonHashedPasswrd = TEST_PATIENT1.password;
 
 describe('OLD: REST API requests on /api/login (expects test users to be added)', () => {
   beforeAll(async () => {

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -58,7 +58,7 @@ describe('OLD: REST API requests on /api/login (expects test users to be added)'
   });
 });
 
-describe('JWT Token: REST API requests on /api/login (expects test users to be added)', () => {
+/* describe('JWT Token: REST API requests on /api/login (expects test users to be added)', () => {
   beforeAll(async () => {
     // Clean the test database first
     await User.deleteMany({});
@@ -104,7 +104,7 @@ describe('JWT Token: REST API requests on /api/login (expects test users to be a
     const { body } = result;
     expect(body.message).toContain('Invalid Username or Password');
   });
-});
+}); */
 
 // Close mongoose connection from supertest(app)
 afterAll(() => {

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -15,7 +15,7 @@ const { TEST_DOCTOR1 } = usersHelper.testDoctors;
 const nonHashedPassword = TEST_PATIENT1.password;
 
 describe('OLD: REST API requests on /api/login (expects test users to be added)', () => {
-  beforeAll(async () => {
+  beforeEach(async () => {
     // Clean the test database first
     await User.deleteMany({});
 
@@ -59,7 +59,7 @@ describe('OLD: REST API requests on /api/login (expects test users to be added)'
 });
 
 describe('JWT Token: REST API requests on /api/login (expects test users to be added)', () => {
-  beforeAll(async () => {
+  beforeEach(async () => {
     // Clean the test database first
     await User.deleteMany({});
     TEST_PATIENT1.password = await bcrypt.hash(TEST_PATIENT1.password, 10);
@@ -83,6 +83,7 @@ describe('JWT Token: REST API requests on /api/login (expects test users to be a
     const userId = await usersHelper.getUserId(TEST_PATIENT1);
 
     const claim = { id: userId };
+    console.log(claim);
     const jtoken = jwt.sign(claim, process.env.ACCESS_TOKEN_SECRET, { expiresIn: '2h' });
 
     // Checking the response body

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -1,7 +1,7 @@
 const mongoose = require('mongoose');
 const supertest = require('supertest');
-// const bcrypt = require('bcrypt');
-// const jwt = require('jsonwebtoken');
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
 const app = require('../app');
 const User = require('../models/user');
 const usersHelper = require('./helperUsers');
@@ -12,7 +12,7 @@ const api = supertest(app);
 // Get predefined test users from usersHelper
 const { TEST_PATIENT1, TEST_PATIENT2 } = usersHelper.testPatients;
 const { TEST_DOCTOR1 } = usersHelper.testDoctors;
-// const nonHashedPasswrd = TEST_PATIENT1.password;
+const nonHashedPassword = TEST_PATIENT1.password;
 
 describe('OLD: REST API requests on /api/login (expects test users to be added)', () => {
   beforeAll(async () => {
@@ -58,7 +58,7 @@ describe('OLD: REST API requests on /api/login (expects test users to be added)'
   });
 });
 
-/* describe('JWT Token: REST API requests on /api/login (expects test users to be added)', () => {
+describe('JWT Token: REST API requests on /api/login (expects test users to be added)', () => {
   beforeAll(async () => {
     // Clean the test database first
     await User.deleteMany({});
@@ -80,8 +80,9 @@ describe('OLD: REST API requests on /api/login (expects test users to be added)'
       .expect('Content-Type', /application\/json/);
 
     const { body } = result;
+    const userId = await usersHelper.getUserId(TEST_PATIENT1);
 
-    const claim = { email: TEST_PATIENT1.email, role: TEST_PATIENT1.role };
+    const claim = { id: userId };
     const jtoken = jwt.sign(claim, process.env.ACCESS_TOKEN_SECRET, { expiresIn: '2h' });
 
     // Checking the response body
@@ -104,7 +105,7 @@ describe('OLD: REST API requests on /api/login (expects test users to be added)'
     const { body } = result;
     expect(body.message).toContain('Invalid Username or Password');
   });
-}); */
+});
 
 // Close mongoose connection from supertest(app)
 afterAll(() => {

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -83,7 +83,6 @@ describe('JWT Token: REST API requests on /api/login (expects test users to be a
     const userId = await usersHelper.getUserId(TEST_PATIENT1);
 
     const claim = { id: userId };
-    console.log(claim);
     const jtoken = jwt.sign(claim, process.env.ACCESS_TOKEN_SECRET, { expiresIn: '2h' });
 
     // Checking the response body

--- a/tests/users.test.js
+++ b/tests/users.test.js
@@ -12,7 +12,7 @@ const { TEST_PATIENT1, TEST_PATIENT2 } = usersHelper.testPatients;
 const { TEST_DOCTOR1 } = usersHelper.testDoctors;
 
 describe('REST API requests on /api/users/ (expects test users to be added)', () => {
-  beforeEach(async () => {
+  beforeAll(async () => {
     // Clean the test database first
     await User.deleteMany({});
     TEST_PATIENT1.password = await bcrypt.hash(TEST_PATIENT1.password, 10);

--- a/tests/users.test.js
+++ b/tests/users.test.js
@@ -12,7 +12,7 @@ const { TEST_PATIENT1, TEST_PATIENT2 } = usersHelper.testPatients;
 const { TEST_DOCTOR1 } = usersHelper.testDoctors;
 
 describe('REST API requests on /api/users/ (expects test users to be added)', () => {
-  beforeAll(async () => {
+  beforeEach(async () => {
     // Clean the test database first
     await User.deleteMany({});
     TEST_PATIENT1.password = await bcrypt.hash(TEST_PATIENT1.password, 10);


### PR DESCRIPTION
Payload for token was reverted to old way of using email and role in order to match with test, however, id should be embedded instead and used to to make request to get any other necessary info such as email or role.